### PR TITLE
9 allow fields in a group to be shownhidden as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,3 +72,12 @@ Paddy's day mega-release
 - A functioning CLI to create icenberg ready ACF gutenberg blocks
 - icenberg.yaml config support
 
+## [v0.5.1] 2025-03-21
+
+### Added
+- Allows pruning of unwanted fields from groups and repeaters
+- Adds wrapping class to synchronise ACF block presentation on front and backends.
+
+### fixed
+- fixed some errors in the stubs
+

--- a/README.md
+++ b/README.md
@@ -196,19 +196,34 @@ which will print out something like
 Depending on the settings in your group.
 
 
-## Conditionals
+## Conditionals and manipulations
 
 #### `field($field_name)`
 
-you can use icenberg to evaluate fields too, using the `field()` method in conjucntion with the below methods. `field()` takes the field name as an argument and returns the icenberg instance for method chaining.
+you can use icenberg to evaluate fields and do some more comlplex field manipualtion too, using the `field()` method in conjucntion with the below methods. `field()` takes the field name as an argument and returns the icenberg instance for method chaining.
 
  ```php
  $icenberg->field($field_name)
  ```
+#### `get($tag)`
+Returns the icenbergified field html (in the same way as get_element).
+
+```php
+$icenberg->field('saxaphone')->get()
+```
+
+#### `prune($exclusions)`
+
+pass an array of field names to the prune method to remove them from a group 
+
+```php
+$group = $icenberg->field('bad_singers')->prune(['chris_de_burgh'])->get();
+
+```
 
 #### `is($value)`
 
-returns true if the value of the field equals the argument to `is()`. You don't need to check for a fields existance before using these methods as they will do it for you and return `false` if they don't.
+returns true if the value of the field equals the argument passed to `is()`. You don't need to check for a fields existance before using these methods as they will do it for you and return `false` if they don't.
 
 ```php
  if ($icenberg->field('font_colour')->is('red')) :
@@ -230,7 +245,9 @@ if ($icenberg->field('range_test')->lessThan(51)) :
         $icenberg->get_element('cta_image'),
     ]);
 endif;
+
 ```
+
 
 ## Maverick Specific
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Using Icenberg's methods we can render acf fields complete with BEM classes and 
 
 It is designed to be used primarily with flexible content fields and ACF Gutenberg blocks but could also work within other scenarios, in theory.
 
-Note: The `buttons` and `settings` methods rely on Maverick specific setups, we'll make these more generally usable in the future.
+Note: The `buttons` and `settings` methods rely on Maverick specific setups and are not intended for general use.
 
 
 ### Getting Started
@@ -214,7 +214,7 @@ $icenberg->field('saxaphone')->get()
 
 #### `prune($exclusions)`
 
-pass an array of field names to the prune method to remove them from a group 
+pass an array of field names to the prune method to remove them from a group or from a repeater row.
 
 ```php
 $group = $icenberg->field('bad_singers')->prune(['chris_de_burgh'])->get();

--- a/src/Blocks/Wrap.php
+++ b/src/Blocks/Wrap.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace MVRK\Icenberg\Blocks;
+
+use MVRK\Icenberg\Fields\Settings;
+use MVRK\Icenberg\Icenberg;
+
+/**
+ * Prepare ACF Gutenberg blocks so that their structure
+ * is more flexible content block like (good, normal) and
+ * less Gutenberg block like (lame, bad).
+ */
+class Wrap
+{
+    /**
+     * We want to wrap our block on the frontend but not in the wordpress
+     * editor where its already wrapped. This makes consistent styling
+     * possible across both, theoretically anywway.
+     *
+     * @param [type] $content
+     * @return void
+     */
+    public static function create($content, $block = null, $wrap_inner = true,)
+    {
+
+        if (!$content) {
+            return '';
+        }
+
+        if (is_array($content)) {
+            $content = implode($content);
+        }
+
+        return self::buildInner($content, $block, $wrap_inner);
+    }
+
+    /**
+     * matches the outer wrapper that wordpress puts over the block
+     * in the preview screen (but not on the frontend).
+     *
+     * native settings are applied here.
+     *
+     * @param [type] $content
+     * @return void
+     */
+    public static function buildOuter($content)
+    {
+        if (is_admin() && acf_is_block_editor()) {
+            return $content;
+        }
+
+        $wrapper_attributes = get_block_wrapper_attributes();
+
+        return sprintf('<div %s>%s</div>', $wrapper_attributes, $content);
+    }
+
+    /**
+     * Wraps content in an internal wrapper with non default
+     * settings applied via an icenberg settings field.
+     *
+     */
+    public static function buildInner($content, $block, $wrap_inner)
+    {
+        $settings = '';
+
+        if ($block) {
+            $classname = str_replace('acf/', '', $block['name']);
+
+            $classname = str_replace('_', '-', $classname);
+
+            $classes = ['wrapper', 'wp-block-acf-' . $classname . "__wrapper"];
+
+            $block_settings = null;
+
+            if (get_field('block_settings')) {
+                $block_settings = get_field('block_settings');
+            }
+
+            $settings = (new Icenberg($block['title']))->settings($block_settings, $classes);
+        }
+
+        if ($wrap_inner) {
+            $content =  sprintf('<div %s>%s</div>', $settings, $content);
+        }
+
+        return self::buildOuter($content);
+    }
+}

--- a/src/Fields/Group.php
+++ b/src/Fields/Group.php
@@ -35,4 +35,9 @@ class Group extends Base
 
         return $group;
     }
+
+    public function dig($field_object, $icenberg)
+    {
+        return $this;
+    }
 }

--- a/src/Fields/Settings.php
+++ b/src/Fields/Settings.php
@@ -16,7 +16,16 @@ class Settings extends Base
     protected $id_string;
 
     protected $standard = [
-        'unique_id', 'orientation', 'padding_bottom', 'padding_top', 'motif_background', 'section_width', 'inner_background_colour', 'section_background_colour', 'background_image', 'background_video'
+        'unique_id',
+        'orientation',
+        'padding_bottom',
+        'padding_top',
+        'motif_background',
+        'section_width',
+        'inner_background_colour',
+        'section_background_colour',
+        'background_image',
+        'background_video'
     ];
 
     public function __construct($settings, $classes = [])

--- a/src/Icenberg.php
+++ b/src/Icenberg.php
@@ -8,6 +8,7 @@ use MVRK\Icenberg\Fields\Group;
 use MVRK\Icenberg\Fields\Repeater;
 use MVRK\Icenberg\Fields\Buttons;
 use MVRK\Icenberg\Fields\Settings;
+use MVRK\Icenberg\Fields\Base;
 
 /**
  * Magically clean up block templates by standardising the
@@ -80,7 +81,7 @@ class Icenberg
             return null;
         }
 
-        return (new Buttons)->getElement($field_object, $this->layout);
+        return (new Buttons())->getElement($field_object, $this->layout);
     }
 
     public function the_buttons($field_name)
@@ -109,7 +110,7 @@ class Icenberg
         if (get_sub_field($field_name)) {
             $this->field = get_sub_field($field_name);
             $this->field_object = get_sub_field_object($field_name);
-        } else if (get_field($field_name)) {
+        } elseif (get_field($field_name)) {
             $this->field = get_field($field_name);
             $this->field_object = get_field_object($field_name);
         }
@@ -134,11 +135,20 @@ class Icenberg
 
         if (get_sub_field($field_name)) {
             $field_object = get_sub_field_object($field_name);
-        } else if (get_field($field_name)) {
+        } elseif (get_field($field_name)) {
             $field_object = get_field_object($field_name);
         }
 
         return $field_object;
+    }
+
+    public function prune($exclusions)
+    {
+        if (!$this->field) {
+            return false;
+        }
+
+        dd($this->field_object);
     }
 
 
@@ -256,7 +266,6 @@ class Icenberg
     }
 
 
-
     /**
      * Find out what type of field we're
      * dealing with and route accordingly.
@@ -277,28 +286,27 @@ class Icenberg
 
         $type = $field_object['type'];
 
-
         if ($type === 'group') {
-            return (new Group)->getElement($field_object, $this);
+            return (new Group())->getElement($field_object, $this);
         }
 
         if ($type === 'repeater') {
-            return (new Repeater)->getElement($field_object, $this);
+            return (new Repeater())->getElement($field_object, $this);
         }
 
         if ($type === 'flexible_content') {
-            return (new FlexibleContent)->getElement($field_object, $this);
+            return (new FlexibleContent())->getElement($field_object, $this);
         }
 
         if ($type === 'relationship') {
-            return (new Relationship)->getElement($field_object, $this);
+            return (new Relationship())->getElement($field_object, $this);
         }
 
         $pascal = str_replace('_', '', ucwords($type, '_'));
 
         $classname = "\\MVRK\Icenberg\Fields\\" . $pascal;
 
-        return (new $classname)->getElement($field_object, $this->layout, $tag);
+        return (new $classname())->getElement($field_object, $this->layout, $tag);
     }
 
 

--- a/src/Icenberg.php
+++ b/src/Icenberg.php
@@ -2,6 +2,7 @@
 
 namespace MVRK\Icenberg;
 
+use MVRK\Icenberg\Blocks\Wrap;
 use MVRK\Icenberg\Fields\FlexibleContent;
 use MVRK\Icenberg\Fields\Relationship;
 use MVRK\Icenberg\Fields\Group;
@@ -327,5 +328,18 @@ class Icenberg
     {
         $layout = str_replace('_', '-', $this->layout);
         return "<{$tag} class='block--{$layout}__{$class}'>" . implode($elements)  . "</{$tag}>";
+    }
+
+    /**
+     * Wrap a Gutenberg block
+     *
+     * @param [type] $content
+     * @param [type] $block_settings
+     * @param boolean $wrap_inner
+     * @return void
+     */
+    public static function wrap($content, $block_settings = null, $wrap_inner = true)
+    {
+        echo Wrap::create($content, $block_settings, $wrap_inner);
     }
 }

--- a/stubs/block.json.stub
+++ b/stubs/block.json.stub
@@ -2,11 +2,16 @@
     "name": "acf/{block_name}",
     "title": "{block_title}",
     "category": "formatting",
+    "style": "icenberg-{block_name}-css",
     "acf": {
         "mode": "preview",
         "renderTemplate": "{block_name}.php"
     },
     "supports": {
-        "anchor": true
+        "anchor": true,
+           "align": [
+            "full",
+            "wide"
+        ],
     }
 }

--- a/stubs/block.php.stub
+++ b/stubs/block.php.stub
@@ -4,10 +4,12 @@ use MVRK\Icenberg\Icenberg;
 
 $icenberg = new Icenberg(strtolower($block['title']));
 
-$icenberg->enclose('text', [
-    //$icenberg->get_element('your_sub_field'),
-   // $icenberg->get_element('another_sub_field')
-]);
-
-
-// $icenberg->the_element('some_third_field');
+$icenberg::wrap(
+    [
+        $icenberg->get_element('a_field'),
+        $icenberg->get_element('another_field'),
+        $icenberg->get_element('a_third_field')
+    ],
+    $block,
+    true
+);

--- a/stubs/block.scss.stub
+++ b/stubs/block.scss.stub
@@ -1,21 +1,6 @@
-.block--{{ block }} {
-    .section__inner {
+.wp-block-acf-{{ block }} {
 
-    }
+   &__wrapper {
 
-    .wrapper {
-
-    }
-
-    &__content {
-
-    }
-
-    &__text {
-
-    }
-
-    &__image {
-
-    }
+   }
 }


### PR DESCRIPTION
- allows for pruning of items in a group or repeater row (addresses #9)  
- adds wrapping for gutenberg blocks so that they can match the backend styling

