### PR TITLE
re-adds ability to pass custom attributes to `enclose`/`get_enclose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ Paddy's day mega-release
 - Json stub now valid
 - hyphens and underscores in acf gutenberg blocks don't work for some reason, handled this in cli
 
-## [v0.7.0] 2025-84-08
+## [v0.7.0] 2025-04-08
 Major changes to allow Icenberg to work well outside of the loop and the confines of 'block'
 
 ### Added 
@@ -134,22 +134,27 @@ Major changes to allow Icenberg to work well outside of the loop and the confine
 ### Removed
 - removed experimental Preview formatting as was too specific to be useful and was an annoyance on relationship fields and post objects where you're more likely to just want a formatted link.
 
-## [v0.7.1] 2025-84-08
+## [v0.7.1] 2025-04-08
 
 ### Fixed
 - implementation bugs in out of loop fields
 
-## [v0.8.0] 2025-84-10
+## [v0.8.0] 2025-04-10
 
 ### Added
 - Modifiers to complete the BEM
 
-## [v0.8.2] 2025-84-11
+## [v0.8.2] 2025-04-11
 
 ### Fixed
 - Bug where the field name was being wiped in option fields
 
-## [v0.8.3] 2025-84-11
+## [v0.8.3] 2025-04-11
 
 ### Fixed
 - Whitespace at tail of css classes
+
+## [v0.8.4] 2025-04-23
+
+### Fixed
+- Ability to pass custom attributes to `enclose` and `get_enclose` re-added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       - [`get_element($field_name, $tag = 'div', $modifiers = [])`](#get_elementfield_name-tag--div-modifiers--)
       - [`the_element($field_name, $tag = 'div', $modifiers = [])`](#the_elementfield_name-tag--div-modifiers--)
       - [Global Options](#global-options)
-      - [`enclose($class, array $elements, $tag = 'div', $attrs = [], $modifiers = [])`](#encloseclass-array-elements-tag--div-attrs--modifiers--)
+      - [`enclose($class, array $elements, $tag = 'div', $attrs = [], $modifiers = [])`](#encloseclass-array-elements-tag--div-attrs---modifiers--)
   - [Values](#values)
   - [Conditionals and manipulations](#conditionals-and-manipulations)
       - [`field($field_name)`](#fieldfield_name)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       - [`get_element($field_name, $tag = 'div', $modifiers = [])`](#get_elementfield_name-tag--div-modifiers--)
       - [`the_element($field_name, $tag = 'div', $modifiers = [])`](#the_elementfield_name-tag--div-modifiers--)
       - [Global Options](#global-options)
-      - [`enclose($class, array $elements, $tag = 'div', $modifiers = [])`](#encloseclass-array-elements-tag--div-modifiers--)
+      - [`enclose($class, array $elements, $tag = 'div', $attrs = [], $modifiers = [])`](#encloseclass-array-elements-tag--div-attrs--modifiers--)
   - [Values](#values)
   - [Conditionals and manipulations](#conditionals-and-manipulations)
       - [`field($field_name)`](#fieldfield_name)
@@ -191,13 +191,14 @@ $ice->the_element('field_name, options');
 ```
 
 
-#### `enclose($class, array $elements, $tag = 'div', $modifiers = [])`
+#### `enclose($class, array $elements, $tag = 'div', $attrs = [], $modifiers = [])`
 
 | Argument     | Type    | Required | Description                       |
 |--------------|---------|----------|-----------------------------------|
 | `$class`     | string  | Yes      | Classname to apply to wrapper div (BEM modifiers will be appended automatically) |
 | `$elements`  | array   | Yes      | Array of rendered HTML elements (e.g. `get_element()` results or strings) |
 | `$tag`       | string  | No       | The HTML tag to wrap the element in. Defaults to `'div'` |
+| `$attrs`     | array   | No       | An array of additional attributes to apply to the wrapper element |
 | `$modifiers` | array   | No       | An array of modifiers to use as BEM classes |
 
 Enclose is a utility for wrapping multiple icenberg fields in a container div without having to use a ?> anywhere. You just need to pass it a classname (without prefixes as these will be applied by icenberg). So clean!

--- a/src/Icenberg.php
+++ b/src/Icenberg.php
@@ -571,9 +571,9 @@ class Icenberg
      * @param ?array $modifiers BEM modifiers for class generation
      * @return void
      */
-    public function enclose($class, $elements = [], $tag = 'div', $modifiers = [])
+    public function enclose($class, $elements = [], $tag = 'div', $attrs = [], $modifiers = [])
     {
-        echo $this->get_enclose($class, $elements, $tag, $modifiers);
+        echo $this->get_enclose($class, $elements, $tag, $attrs, $modifiers);
     }
 
     /**
@@ -585,7 +585,7 @@ class Icenberg
      * @param ?array $modifiers BEM modifiers for class generation
      * @return string
      */
-    public function get_enclose($class, $elements = [], $tag = 'div', $modifiers = [])
+    public function get_enclose($class, $elements = [], $tag = 'div', $attrs = [], $modifiers = [])
     {
         $layout = str_replace('_', '-', $this->layout);
         $base_class = "{$this->prefix}{$layout}";
@@ -594,10 +594,24 @@ class Icenberg
             $base_class .= "__{$class}";
         }
 
-        $modifier_classes = self::generateModifierClasses($base_class, $modifiers);
-        $classes_string = self::implodeClasses($base_class, $modifier_classes);
+        $additional_classes = '';
+        $additional_attrs = '';
 
-        return "<{$tag} class='{$classes_string}'>" . implode($elements)  . "</{$tag}>";
+        if (count($attrs)) {
+            if (isset($attrs['class'])) { // handle classes separately as we already have a class attribute
+                $additional_classes = $attrs['class'];
+                unset($attrs['class']);
+            }
+
+            $additional_attrs = implode(' ', array_map(function ($key, $val) {
+                return "{$key}='{$val}'";
+            }, array_keys($attrs), array_values($attrs)));
+        }
+
+        $modifier_classes = self::generateModifierClasses($base_class, $modifiers);
+        $classes_string = self::implodeClasses($base_class, $modifier_classes, $additional_classes);
+
+        return "<{$tag} class='{$classes_string}' {$additional_attrs}>" . implode($elements)  . "</{$tag}>";
     }
 
     /**


### PR DESCRIPTION
Functionality accidentally removed during a merge